### PR TITLE
Wrong error message

### DIFF
--- a/src/seedu/addressbook/data/person/Address.java
+++ b/src/seedu/addressbook/data/person/Address.java
@@ -9,7 +9,7 @@ import seedu.addressbook.data.exception.IllegalValueException;
 public class Address {
 
     public static final String EXAMPLE = "123, some street";
-    public static final String MESSAGE_ADDRESS_CONSTRAINTS = "Person addresses can be in any format";
+    public static final String MESSAGE_ADDRESS_CONSTRAINTS = "Person address is not in the correct format";
     public static final String ADDRESS_VALIDATION_REGEX = ".+";
 
     public final String value;


### PR DESCRIPTION
Exception supposed to throw error message. Threw a message saying any format is correct when only a certain format is accepted. Corrected to show a message saying an incorrect format is entered.