### PR TITLE
[W5.4][W11-A2]Zhan Yu

### DIFF
--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -6,7 +6,7 @@ import seedu.addressbook.data.person.ReadOnlyPerson;
 
 import java.util.List;
 
-import static seedu.addressbook.ui.TextUi.DISPLAYED_INDEX_OFFSET;
+import static seedu.addressbook.ui.Formatter.DISPLAYED_INDEX_OFFSET;
 
 /**
  * Represents an executable command.

--- a/src/seedu/addressbook/commands/HelpCommand.java
+++ b/src/seedu/addressbook/commands/HelpCommand.java
@@ -17,14 +17,14 @@ public class HelpCommand extends Command {
     public CommandResult execute() {
         return new CommandResult(
                 AddCommand.MESSAGE_USAGE
-                + "\n" + DeleteCommand.MESSAGE_USAGE
-                + "\n" + ClearCommand.MESSAGE_USAGE
-                + "\n" + FindCommand.MESSAGE_USAGE
-                + "\n" + ListCommand.MESSAGE_USAGE
-                + "\n" + ViewCommand.MESSAGE_USAGE
-                + "\n" + ViewAllCommand.MESSAGE_USAGE
-                + "\n" + HelpCommand.MESSAGE_USAGE
-                + "\n" + ExitCommand.MESSAGE_USAGE
+                + "\n\n" + DeleteCommand.MESSAGE_USAGE
+                + "\n\n" + ClearCommand.MESSAGE_USAGE
+                + "\n\n" + FindCommand.MESSAGE_USAGE
+                + "\n\n" + ListCommand.MESSAGE_USAGE
+                + "\n\n" + ViewCommand.MESSAGE_USAGE
+                + "\n\n" + ViewAllCommand.MESSAGE_USAGE
+                + "\n\n" + HelpCommand.MESSAGE_USAGE
+                + "\n\n" + ExitCommand.MESSAGE_USAGE
         );
     }
 }

--- a/src/seedu/addressbook/common/Messages.java
+++ b/src/seedu/addressbook/common/Messages.java
@@ -5,8 +5,8 @@ package seedu.addressbook.common;
  */
 public class Messages {
 
-    public static final String MESSAGE_GOODBYE = "Good bye!";
-    public static final String MESSAGE_INIT_FAILED = "Failed to initialise address book application. Exiting...";
+    public static final String MESSAGE_GOODBYE = "Good bye!\n%1$s\n%1$s";
+    public static final String MESSAGE_INIT_FAILED = "Failed to initialise address book application. Exiting...\n%1$s\n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSON_NOT_IN_ADDRESSBOOK = "Person could not be found in address book";
@@ -15,4 +15,13 @@ public class Messages {
             "java seedu.addressbook.Main [STORAGE_FILE_PATH]";
     public static final String MESSAGE_WELCOME = "Welcome to your Address Book!";
     public static final String MESSAGE_USING_STORAGE_FILE = "Using storage file : %1$s";
+    public static final String MESSAGE_PROMPT_USER_INPUT = "%1$sEnter command: ";
+    public static final String MESSAGE_FEEDBACK_COMMAND_ECHO = "[Command entered:%1$s]";
+    public static final String MESSAGE_FEEDBACK_WELCOME_MESSAGE = "%1$s\n%1$s"
+            + "\n" + MESSAGE_WELCOME
+            + "\n" + "%2$s"
+            + "\n" + MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE
+            + "\n" + "%3$s"
+            + "\n%1$s";
+    public static final String MESSAGE_FEEDBACK_COMMAND_RESULT = "%1$s\n%2$s";
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -22,5 +22,13 @@ public class Formatter {
     /** Offset required to convert between 1-indexing and 0-indexing.  */
     public static final int DISPLAYED_INDEX_OFFSET = 1;
 
+    //TODO: Add maximum line cutter (truncate help text to next line e.g. help etc if values are too long)
 
+    //===================================== Message Constants ===========================================
+    private static final String MESSAGE_PROMPT_USER_INPUT = "Enter command: ";
+
+    public static String getUserInputPrompt() {
+        return MESSAGE_PROMPT_USER_INPUT;
+    }
+    
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -35,7 +35,7 @@ public class Formatter {
 
 
     //===================================== Message Constants ===========================================
-    private static final String MESSAGE_PROMPT_USER_INPUT = "Enter command: ";
+    private static final String MESSAGE_PROMPT_USER_INPUT = LINE_PREFIX + "Enter command: ";
     private static final String MESSAGE_FEEDBACK_COMMAND_ECHO = "[Command entered:%1$s]";
     private static final String MESSAGE_FEEDBACK_WELCOME_MESSAGE = DIVIDER + "\n" + DIVIDER
             + "\n" + MESSAGE_WELCOME

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -49,7 +49,6 @@ public class Formatter {
     private static final String MESSAGE_FEEDBACK_GOODBYE_MESSAGE = MESSAGE_GOODBYE + "\n" + DIVIDER + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_INIT_FAILED = MESSAGE_INIT_FAILED + "\n" + DIVIDER + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_COMMAND_RESULT = "%1$s" + "\n" + DIVIDER;
-    private static final String MESSAGE_FORMATTED_FEEDBACK = LINE_PREFIX + "%1$s";
 
     /**
      * Returns a formatted string collection obtained from a big string into several,

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -46,6 +46,7 @@ public class Formatter {
     private static final String MESSAGE_FEEDBACK_GOODBYE_MESSAGE = MESSAGE_GOODBYE + "\n" + DIVIDER + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_INIT_FAILED = MESSAGE_INIT_FAILED + "\n" + DIVIDER + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_COMMAND_RESULT = "%1$s" + "\n" + DIVIDER;
+    private static final String MESSAGE_FORMATTED_FEEDBACK = LINE_PREFIX + "%1$s";
 
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
@@ -67,6 +68,10 @@ public class Formatter {
     
     public static String getInitFailedMessage() {
         return MESSAGE_FEEDBACK_INIT_FAILED;
+    }
+    
+    public static String getFormattedFeedbackMessage(String message) {
+        return String.format(MESSAGE_FORMATTED_FEEDBACK, message.replace("\n", LS + LINE_PREFIX));
     }
     
     public static String getCommandResultMessage(String feedbackMessage) {

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -1,5 +1,10 @@
 package seedu.addressbook.ui;
 
+import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
+import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
+import static seedu.addressbook.common.Messages.MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE;
+import static seedu.addressbook.common.Messages.MESSAGE_WELCOME;
+
 public class Formatter {
 
 

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -2,6 +2,9 @@ package seedu.addressbook.ui;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
 
 import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
 import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
@@ -17,7 +20,7 @@ public class Formatter {
 
     /** The maximum console width in number of monospaced characters, not inclusive of LINE_PREFIX */
     public static final int MAX_CONSOLE_WIDTH = 72;
-    //TODO: Add maximum line cutter (truncate help text to next line e.g. help etc if values are too long)
+    private static final String SUBLINE_PREFIX = "    ";
     
     /** A decorative prefix added to the beginning of lines printed by AddressBook */
     private static final String LINE_PREFIX = "|| ";
@@ -48,6 +51,54 @@ public class Formatter {
     private static final String MESSAGE_FEEDBACK_COMMAND_RESULT = "%1$s" + "\n" + DIVIDER;
     private static final String MESSAGE_FORMATTED_FEEDBACK = LINE_PREFIX + "%1$s";
 
+    /**
+     * Returns a formatted string collection obtained from a big string into several,
+     * smaller strings that can be shown to the user directly.
+     * 
+     * @param longString A very long string possibly separated by line breaks.
+     * @return An array of line strings that can be shown to the user.
+     */
+    public static Queue<String> getFormattedLines(String longString) {
+        String[] lines = longString.split("\n");
+        Queue<String> formattedLines = new LinkedList<>();
+        for (String line: lines) {
+            if (line.length() > MAX_CONSOLE_WIDTH) {
+                formattedLines.add(getTruncatedLines(line));
+            } else {
+                formattedLines.add(LINE_PREFIX + line);
+            }
+        }
+        return formattedLines;
+    }
+
+    /**
+     * Gets a single formatted string for multiple lines from a truncated line.
+     * 
+     * @param longLine a long string to be truncated into smaller strings
+     * @return a formatted string with words reaching no more than the maximum screen width per line.
+     */
+    private static String getTruncatedLines(String longLine) {
+        StringTokenizer tokenizer = new StringTokenizer(longLine, " ");
+        StringBuilder output = new StringBuilder(longLine.length());
+        output.append(LINE_PREFIX);
+        int lineLength = 0;
+        while (tokenizer.hasMoreTokens()) {
+            String currentWord = tokenizer.nextToken();
+            
+            if (lineLength + currentWord.length() > MAX_CONSOLE_WIDTH) {
+                output.append(getLineEnding() + SUBLINE_PREFIX);
+                lineLength = SUBLINE_PREFIX.length();
+            }
+            output.append(currentWord + " ");
+            lineLength += currentWord.length() + 1;
+        }
+        return output.toString();
+    }
+    
+    private static String getLineEnding() {
+        return LS + LINE_PREFIX;
+    }
+    
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
     }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -3,6 +3,7 @@ package seedu.addressbook.ui;
 import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
 import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
 import static seedu.addressbook.common.Messages.MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE;
+import static seedu.addressbook.common.Messages.MESSAGE_USING_STORAGE_FILE;
 import static seedu.addressbook.common.Messages.MESSAGE_WELCOME;
 
 /**
@@ -30,6 +31,12 @@ public class Formatter {
     //===================================== Message Constants ===========================================
     private static final String MESSAGE_PROMPT_USER_INPUT = "Enter command: ";
     private static final String MESSAGE_FEEDBACK_COMMAND_ECHO = "[Command entered:%1$s]";
+    private static final String MESSAGE_FEEDBACK_WELCOME_MESSAGE = DIVIDER + "\n" + DIVIDER
+            + "\n" + MESSAGE_WELCOME
+            + "\n" + "%1$s"
+            + "\n" + MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE
+            + "\n" + "%2$s"
+            + "\n" + DIVIDER;
 
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
@@ -37,5 +44,11 @@ public class Formatter {
     
     public static String getUserCommandEcho(String userCommand) {
         return String.format(MESSAGE_FEEDBACK_COMMAND_ECHO, userCommand);
+    }
+    
+    public static String getWelcomeMessage(String version, String storageFilePath) {
+        return String.format(MESSAGE_FEEDBACK_WELCOME_MESSAGE,
+                version,
+                String.format(MESSAGE_USING_STORAGE_FILE, storageFilePath));
     }
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -43,6 +43,7 @@ public class Formatter {
             + "\n" + "%2$s"
             + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_GOODBYE_MESSAGE = MESSAGE_GOODBYE + "\n" + DIVIDER + "\n" + DIVIDER;
+    private static final String MESSAGE_FEEDBACK_INIT_FAILED = MESSAGE_INIT_FAILED + "\n" + DIVIDER + "\n" + DIVIDER;
 
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
@@ -60,5 +61,9 @@ public class Formatter {
     
     public static String getGoodbyeMessage() {
         return MESSAGE_FEEDBACK_GOODBYE_MESSAGE;
+    }
+    
+    public static String getInitFailedMessage() {
+        return MESSAGE_FEEDBACK_INIT_FAILED;
     }
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -1,5 +1,7 @@
 package seedu.addressbook.ui;
 
+import java.util.Collections;
+
 import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
 import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
 import static seedu.addressbook.common.Messages.MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE;
@@ -12,13 +14,17 @@ import static seedu.addressbook.common.Messages.MESSAGE_WELCOME;
 public class Formatter {
 
 
+    /** The maximum console width in number of monospaced characters, not inclusive of LINE_PREFIX */
+    public static final int MAX_CONSOLE_WIDTH = 72;
+    //TODO: Add maximum line cutter (truncate help text to next line e.g. help etc if values are too long)
+    
     /** A decorative prefix added to the beginning of lines printed by AddressBook */
     private static final String LINE_PREFIX = "|| ";
 
     /** A platform independent line separator. */
     private static final String LS = System.lineSeparator();
 
-    private static final String DIVIDER = "===================================================";
+    private static final String DIVIDER = String.join("", Collections.nCopies(MAX_CONSOLE_WIDTH, "="));
 
     /** Format of indexed list item */
     private static final String MESSAGE_INDEXED_LIST_ITEM = "\t%1$d. %2$s";
@@ -26,7 +32,6 @@ public class Formatter {
     /** Offset required to convert between 1-indexing and 0-indexing.  */
     public static final int DISPLAYED_INDEX_OFFSET = 1;
 
-    //TODO: Add maximum line cutter (truncate help text to next line e.g. help etc if values are too long)
 
     //===================================== Message Constants ===========================================
     private static final String MESSAGE_PROMPT_USER_INPUT = "Enter command: ";

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -5,6 +5,9 @@ import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
 import static seedu.addressbook.common.Messages.MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE;
 import static seedu.addressbook.common.Messages.MESSAGE_WELCOME;
 
+/**
+ * Text formatter utility class for text UI.
+ */
 public class Formatter {
 
 
@@ -26,9 +29,13 @@ public class Formatter {
 
     //===================================== Message Constants ===========================================
     private static final String MESSAGE_PROMPT_USER_INPUT = "Enter command: ";
+    private static final String MESSAGE_FEEDBACK_COMMAND_ECHO = "[Command entered:%1$s]";
 
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
     }
     
+    public static String getUserCommandEcho(String userCommand) {
+        return String.format(MESSAGE_FEEDBACK_COMMAND_ECHO, userCommand);
+    }
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -44,6 +44,7 @@ public class Formatter {
             + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_GOODBYE_MESSAGE = MESSAGE_GOODBYE + "\n" + DIVIDER + "\n" + DIVIDER;
     private static final String MESSAGE_FEEDBACK_INIT_FAILED = MESSAGE_INIT_FAILED + "\n" + DIVIDER + "\n" + DIVIDER;
+    private static final String MESSAGE_FEEDBACK_COMMAND_RESULT = "%1$s" + "\n" + DIVIDER;
 
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
@@ -66,4 +67,9 @@ public class Formatter {
     public static String getInitFailedMessage() {
         return MESSAGE_FEEDBACK_INIT_FAILED;
     }
+    
+    public static String getCommandResultMessage(String feedbackMessage) {
+        return String.format(MESSAGE_FEEDBACK_COMMAND_RESULT, feedbackMessage);
+    }
+
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -72,18 +72,18 @@ public class Formatter {
     }
 
     /**
-     * Gets a single formatted string for multiple lines from a truncated line.
+     * Returns a single formatted string for multiple lines from a truncated line.
      * 
      * @param longLine a long string to be truncated into smaller strings
      * @return a formatted string with words reaching no more than the maximum screen width per line.
      */
     private static String getTruncatedLines(String longLine) {
-        StringTokenizer tokenizer = new StringTokenizer(longLine, " ");
+        StringTokenizer wordsRemaining = new StringTokenizer(longLine, " ");
         StringBuilder output = new StringBuilder(longLine.length());
         output.append(LINE_PREFIX);
         int lineLength = 0;
-        while (tokenizer.hasMoreTokens()) {
-            String currentWord = tokenizer.nextToken();
+        while (wordsRemaining.hasMoreTokens()) {
+            String currentWord = wordsRemaining.nextToken();
             
             if (lineLength + currentWord.length() > MAX_CONSOLE_WIDTH) {
                 output.append(getLineEnding() + SUBLINE_PREFIX);
@@ -121,15 +121,11 @@ public class Formatter {
         return MESSAGE_FEEDBACK_INIT_FAILED;
     }
     
-    public static String getFormattedFeedbackMessage(String message) {
-        return String.format(MESSAGE_FORMATTED_FEEDBACK, message.replace("\n", LS + LINE_PREFIX));
-    }
-    
     public static String getCommandResultMessage(String feedbackMessage) {
         return String.format(MESSAGE_FEEDBACK_COMMAND_RESULT, feedbackMessage);
     }
 
-    /** Formats a list of strings as a viewable indexed list. */
+    /** Returns a formatted list of strings as a viewable indexed list. */
     public static String getIndexedListForViewing(List<String> listItems) {
         final StringBuilder formatted = new StringBuilder();
         int displayIndex = 0 + DISPLAYED_INDEX_OFFSET;
@@ -141,7 +137,7 @@ public class Formatter {
     }
 
     /**
-     * Formats a string as a viewable indexed list item.
+     * Returns a formatted string as a viewable indexed list item.
      *
      * @param visibleIndex visible index for this listing
      */

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -1,6 +1,7 @@
 package seedu.addressbook.ui;
 
 import java.util.Collections;
+import java.util.List;
 
 import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
 import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
@@ -72,4 +73,24 @@ public class Formatter {
         return String.format(MESSAGE_FEEDBACK_COMMAND_RESULT, feedbackMessage);
     }
 
+    /** Formats a list of strings as a viewable indexed list. */
+    public static String getIndexedListForViewing(List<String> listItems) {
+        final StringBuilder formatted = new StringBuilder();
+        int displayIndex = 0 + DISPLAYED_INDEX_OFFSET;
+        for (String listItem : listItems) {
+            formatted.append(getIndexedListItem(displayIndex, listItem)).append("\n");
+            displayIndex++;
+        }
+        return formatted.toString();
+    }
+
+    /**
+     * Formats a string as a viewable indexed list item.
+     *
+     * @param visibleIndex visible index for this listing
+     */
+    private static String getIndexedListItem(int visibleIndex, String listItem) {
+        return String.format(MESSAGE_INDEXED_LIST_ITEM, visibleIndex, listItem);
+    }
+    
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -6,11 +6,13 @@ import java.util.Queue;
 import java.util.LinkedList;
 import java.util.StringTokenizer;
 
+import static seedu.addressbook.common.Messages.MESSAGE_FEEDBACK_COMMAND_ECHO;
+import static seedu.addressbook.common.Messages.MESSAGE_PROMPT_USER_INPUT;
+import static seedu.addressbook.common.Messages.MESSAGE_USING_STORAGE_FILE;
+import static seedu.addressbook.common.Messages.MESSAGE_FEEDBACK_WELCOME_MESSAGE;
 import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
 import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
-import static seedu.addressbook.common.Messages.MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE;
-import static seedu.addressbook.common.Messages.MESSAGE_USING_STORAGE_FILE;
-import static seedu.addressbook.common.Messages.MESSAGE_WELCOME;
+import static seedu.addressbook.common.Messages.MESSAGE_FEEDBACK_COMMAND_RESULT;
 
 /**
  * Text formatter utility class for text UI.
@@ -35,20 +37,7 @@ public class Formatter {
     
     /** Offset required to convert between 1-indexing and 0-indexing.  */
     public static final int DISPLAYED_INDEX_OFFSET = 1;
-
-
-    //===================================== Message Constants ===========================================
-    private static final String MESSAGE_PROMPT_USER_INPUT = LINE_PREFIX + "Enter command: ";
-    private static final String MESSAGE_FEEDBACK_COMMAND_ECHO = "[Command entered:%1$s]";
-    private static final String MESSAGE_FEEDBACK_WELCOME_MESSAGE = DIVIDER + "\n" + DIVIDER
-            + "\n" + MESSAGE_WELCOME
-            + "\n" + "%1$s"
-            + "\n" + MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE
-            + "\n" + "%2$s"
-            + "\n" + DIVIDER;
-    private static final String MESSAGE_FEEDBACK_GOODBYE_MESSAGE = MESSAGE_GOODBYE + "\n" + DIVIDER + "\n" + DIVIDER;
-    private static final String MESSAGE_FEEDBACK_INIT_FAILED = MESSAGE_INIT_FAILED + "\n" + DIVIDER + "\n" + DIVIDER;
-    private static final String MESSAGE_FEEDBACK_COMMAND_RESULT = "%1$s" + "\n" + DIVIDER;
+    
 
     /**
      * Returns a formatted string collection obtained from a big string into several,
@@ -99,7 +88,7 @@ public class Formatter {
     }
     
     public static String getUserInputPrompt() {
-        return MESSAGE_PROMPT_USER_INPUT;
+        return String.format(MESSAGE_PROMPT_USER_INPUT, LINE_PREFIX);
     }
     
     public static String getUserCommandEcho(String userCommand) {
@@ -108,20 +97,21 @@ public class Formatter {
     
     public static String getWelcomeMessage(String version, String storageFilePath) {
         return String.format(MESSAGE_FEEDBACK_WELCOME_MESSAGE,
+                DIVIDER,
                 version,
                 String.format(MESSAGE_USING_STORAGE_FILE, storageFilePath));
     }
     
     public static String getGoodbyeMessage() {
-        return MESSAGE_FEEDBACK_GOODBYE_MESSAGE;
+        return String.format(MESSAGE_GOODBYE, DIVIDER);
     }
     
     public static String getInitFailedMessage() {
-        return MESSAGE_FEEDBACK_INIT_FAILED;
+        return String.format(MESSAGE_INIT_FAILED, DIVIDER);
     }
     
     public static String getCommandResultMessage(String feedbackMessage) {
-        return String.format(MESSAGE_FEEDBACK_COMMAND_RESULT, feedbackMessage);
+        return String.format(MESSAGE_FEEDBACK_COMMAND_RESULT, feedbackMessage, DIVIDER);
     }
 
     /** Returns a formatted list of strings as a viewable indexed list. */

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -37,6 +37,7 @@ public class Formatter {
             + "\n" + MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE
             + "\n" + "%2$s"
             + "\n" + DIVIDER;
+    private static final String MESSAGE_FEEDBACK_GOODBYE_MESSAGE = MESSAGE_GOODBYE + "\n" + DIVIDER + "\n" + DIVIDER;
 
     public static String getUserInputPrompt() {
         return MESSAGE_PROMPT_USER_INPUT;
@@ -50,5 +51,9 @@ public class Formatter {
         return String.format(MESSAGE_FEEDBACK_WELCOME_MESSAGE,
                 version,
                 String.format(MESSAGE_USING_STORAGE_FILE, storageFilePath));
+    }
+    
+    public static String getGoodbyeMessage() {
+        return MESSAGE_FEEDBACK_GOODBYE_MESSAGE;
     }
 }

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -22,10 +22,10 @@ public class Formatter {
 
     /** The maximum console width in number of monospaced characters, not inclusive of LINE_PREFIX */
     public static final int MAX_CONSOLE_WIDTH = 72;
-    private static final String SUBLINE_PREFIX = "    ";
     
     /** A decorative prefix added to the beginning of lines printed by AddressBook */
-    private static final String LINE_PREFIX = "|| ";
+    private static final String PPREFIX_LINE = "|| ";
+    private static final String PREFIX_SUBLINE = "    ";
 
     /** A platform independent line separator. */
     private static final String LS = System.lineSeparator();
@@ -53,7 +53,7 @@ public class Formatter {
             if (line.length() > MAX_CONSOLE_WIDTH) {
                 formattedLines.add(getTruncatedLines(line));
             } else {
-                formattedLines.add(LINE_PREFIX + line);
+                formattedLines.add(PPREFIX_LINE + line);
             }
         }
         return formattedLines;
@@ -68,14 +68,14 @@ public class Formatter {
     private static String getTruncatedLines(String longLine) {
         StringTokenizer wordsRemaining = new StringTokenizer(longLine, " ");
         StringBuilder output = new StringBuilder(longLine.length());
-        output.append(LINE_PREFIX);
+        output.append(PPREFIX_LINE);
         int lineLength = 0;
         while (wordsRemaining.hasMoreTokens()) {
             String currentWord = wordsRemaining.nextToken();
             
             if (lineLength + currentWord.length() > MAX_CONSOLE_WIDTH) {
-                output.append(getLineEnding() + SUBLINE_PREFIX);
-                lineLength = SUBLINE_PREFIX.length();
+                output.append(getLineEnding() + PREFIX_SUBLINE);
+                lineLength = PREFIX_SUBLINE.length();
             }
             output.append(currentWord + " ");
             lineLength += currentWord.length() + 1;
@@ -84,11 +84,11 @@ public class Formatter {
     }
     
     private static String getLineEnding() {
-        return LS + LINE_PREFIX;
+        return LS + PPREFIX_LINE;
     }
     
     public static String getUserInputPrompt() {
-        return String.format(MESSAGE_PROMPT_USER_INPUT, LINE_PREFIX);
+        return String.format(MESSAGE_PROMPT_USER_INPUT, PPREFIX_LINE);
     }
     
     public static String getUserCommandEcho(String userCommand) {

--- a/src/seedu/addressbook/ui/Formatter.java
+++ b/src/seedu/addressbook/ui/Formatter.java
@@ -1,0 +1,21 @@
+package seedu.addressbook.ui;
+
+public class Formatter {
+
+
+    /** A decorative prefix added to the beginning of lines printed by AddressBook */
+    private static final String LINE_PREFIX = "|| ";
+
+    /** A platform independent line separator. */
+    private static final String LS = System.lineSeparator();
+
+    private static final String DIVIDER = "===================================================";
+
+    /** Format of indexed list item */
+    private static final String MESSAGE_INDEXED_LIST_ITEM = "\t%1$d. %2$s";
+    
+    /** Offset required to convert between 1-indexing and 0-indexing.  */
+    public static final int DISPLAYED_INDEX_OFFSET = 1;
+
+
+}

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -59,7 +59,7 @@ public class TextUi {
      * @return command (full line) entered by the user
      */
     public String getUserCommand() {
-        showToUser(Formatter.getUserInputPrompt());
+        out.print(Formatter.getUserInputPrompt());
         String fullInputLine = in.nextLine();
 
         // silently consume all ignored lines

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -1,7 +1,5 @@
 package seedu.addressbook.ui;
 
-import static seedu.addressbook.common.Messages.MESSAGE_USING_STORAGE_FILE;
-
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -75,15 +73,7 @@ public class TextUi {
 
 
     public void showWelcomeMessage(String version, String storageFilePath) {
-        String storageFileInfo = String.format(MESSAGE_USING_STORAGE_FILE, storageFilePath);
-        showToUser(
-                DIVIDER,
-                DIVIDER,
-                MESSAGE_WELCOME,
-                version,
-                MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE,
-                storageFileInfo,
-                DIVIDER);
+        showToUser(Formatter.getWelcomeMessage(version, storageFilePath));
     }
 
     public void showGoodbyeMessage() {

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -118,27 +118,7 @@ public class TextUi {
 
     /** Shows a list of strings to the user, formatted as an indexed list. */
     private void showToUserAsIndexedList(List<String> list) {
-        showToUser(getIndexedListForViewing(list));
-    }
-
-    /** Formats a list of strings as a viewable indexed list. */
-    private static String getIndexedListForViewing(List<String> listItems) {
-        final StringBuilder formatted = new StringBuilder();
-        int displayIndex = 0 + DISPLAYED_INDEX_OFFSET;
-        for (String listItem : listItems) {
-            formatted.append(getIndexedListItem(displayIndex, listItem)).append("\n");
-            displayIndex++;
-        }
-        return formatted.toString();
-    }
-
-    /**
-     * Formats a string as a viewable indexed list item.
-     *
-     * @param visibleIndex visible index for this listing
-     */
-    private static String getIndexedListItem(int visibleIndex, String listItem) {
-        return String.format(MESSAGE_INDEXED_LIST_ITEM, visibleIndex, listItem);
+        showToUser(Formatter.getIndexedListForViewing(list));
     }
 
 }

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -88,7 +88,7 @@ public class TextUi {
     /** Shows message(s) to the user */
     public void showToUser(String... message) {
         for (String m : message) {
-            out.println(LINE_PREFIX + m.replace("\n", LS + LINE_PREFIX));
+            out.println(Formatter.getFormattedFeedbackMessage(m));
         }
     }
 

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -82,7 +82,7 @@ public class TextUi {
 
 
     public void showInitFailedMessage() {
-        showToUser(MESSAGE_INIT_FAILED, DIVIDER, DIVIDER);
+        showToUser(Formatter.getInitFailedMessage());
     }
 
     /** Shows message(s) to the user */

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -77,7 +77,7 @@ public class TextUi {
     }
 
     public void showGoodbyeMessage() {
-        showToUser(MESSAGE_GOODBYE, DIVIDER, DIVIDER);
+        showToUser(Formatter.getGoodbyeMessage());
     }
 
 

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -1,10 +1,6 @@
 package seedu.addressbook.ui;
 
-import static seedu.addressbook.common.Messages.MESSAGE_GOODBYE;
-import static seedu.addressbook.common.Messages.MESSAGE_INIT_FAILED;
-import static seedu.addressbook.common.Messages.MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE;
 import static seedu.addressbook.common.Messages.MESSAGE_USING_STORAGE_FILE;
-import static seedu.addressbook.common.Messages.MESSAGE_WELCOME;
 
 import java.io.InputStream;
 import java.io.PrintStream;

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.Queue;
 
 import seedu.addressbook.commands.CommandResult;
 import seedu.addressbook.data.person.ReadOnlyPerson;
@@ -88,7 +89,10 @@ public class TextUi {
     /** Shows message(s) to the user */
     public void showToUser(String... message) {
         for (String m : message) {
-            out.println(Formatter.getFormattedFeedbackMessage(m));
+            Queue<String> formattedLines = Formatter.getFormattedLines(m);
+            while (!formattedLines.isEmpty()) {
+                out.println(formattedLines.remove());
+            }
         }
     }
 

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -61,7 +61,7 @@ public class TextUi {
      * @return command (full line) entered by the user
      */
     public String getUserCommand() {
-        out.print(LINE_PREFIX + "Enter command: ");
+        showToUser(Formatter.getUserInputPrompt());
         String fullInputLine = in.nextLine();
 
         // silently consume all ignored lines

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -101,7 +101,7 @@ public class TextUi {
         if (resultPersons.isPresent()) {
             showPersonListView(resultPersons.get());
         }
-        showToUser(result.feedbackToUser, DIVIDER);
+        showToUser(Formatter.getCommandResultMessage(result.feedbackToUser));
     }
 
     /**

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -20,21 +20,7 @@ import seedu.addressbook.data.person.ReadOnlyPerson;
  * Text UI of the application.
  */
 public class TextUi {
-
-    /** A decorative prefix added to the beginning of lines printed by AddressBook */
-    private static final String LINE_PREFIX = "|| ";
-
-    /** A platform independent line separator. */
-    private static final String LS = System.lineSeparator();
-
-    private static final String DIVIDER = "===================================================";
-
-    /** Format of indexed list item */
-    private static final String MESSAGE_INDEXED_LIST_ITEM = "\t%1$d. %2$s";
-
-
-    /** Offset required to convert between 1-indexing and 0-indexing.  */
-    public static final int DISPLAYED_INDEX_OFFSET = 1;
+    
 
     /** Format of a comment input line. Comment lines are silently consumed when reading user input. */
     private static final String COMMENT_LINE_FORMAT_REGEX = "#.*";

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -69,7 +69,7 @@ public class TextUi {
             fullInputLine = in.nextLine();
         }
 
-        showToUser("[Command entered:" + fullInputLine + "]");
+        showToUser(Formatter.getUserCommandEcho(fullInputLine));
         return fullInputLine;
     }
 

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -1,305 +1,372 @@
-|| ===================================================
-|| ===================================================
+|| ========================================================================
+|| ========================================================================
 || Welcome to your Address Book!
 || AddessBook Level 2 - Version 1.0
 || Launch command format: java seedu.addressbook.Main [STORAGE_FILE_PATH]
 || Using storage file : addressbook.xml
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  sfdfd]
-|| add: Adds a person to the address book. Contact details can be marked private by prepending 'p' to the prefix.
+|| add: Adds a person to the address book. Contact details can be marked 
+||     private by prepending 'p' to the prefix. 
 || Parameters: NAME [p]p/PHONE [p]e/EMAIL [p]a/ADDRESS  [t/TAG]...
-|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney
-|| delete: Deletes the person identified by the index number used in the last person listing.
+|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 
+||     2, #02-25 t/friends t/owesMoney 
+|| 
+|| delete: Deletes the person identified by the index number used in the 
+||     last person listing. 
 || Parameters: INDEX
 || Example: delete 1
+|| 
 || Clears address book permanently.
 || Example: clear
-|| find: Finds all persons whose names contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
+|| 
+|| find: Finds all persons whose names contain any of the specified 
+||     keywords (case-sensitive) and displays them as a list with index 
+||     numbers. 
 || Parameters: KEYWORD [MORE_KEYWORDS]...
 || Example: find alice bob charlie
-|| list: Displays all persons in the address book as a list with index numbers.
+|| 
+|| list: Displays all persons in the address book as a list with index 
+||     numbers. 
 || Example: list
-|| view: Views the non-private details of the person identified by the index number in the last shown person listing.
+|| 
+|| view: Views the non-private details of the person identified by the 
+||     index number in the last shown person listing. 
 || Parameters: INDEX
 || Example: view 1
-|| viewall: Views the non-private details of the person identified by the index number in the last shown person listing.
+|| 
+|| viewall: Views the non-private details of the person identified by the 
+||     index number in the last shown person listing. 
 || Parameters: INDEX
 || Example: viewall 1
+|| 
 || help: Shows program usage instructions.
 || Example: help
+|| 
 || exit: Exits the program.
 || Example: exit
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete 1]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view 1]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 1]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  list]
 || 
 || 0 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  add wrong args wrong args]
 || Invalid command format! 
-|| add: Adds a person to the address book. Contact details can be marked private by prepending 'p' to the prefix.
+|| add: Adds a person to the address book. Contact details can be marked 
+||     private by prepending 'p' to the prefix. 
 || Parameters: NAME [p]p/PHONE [p]e/EMAIL [p]a/ADDRESS  [t/TAG]...
-|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney
-|| ===================================================
-|| Enter command: || [Command entered:  add Valid Name 12345 e/valid@email.butNoPhonePrefix a/valid, address]
+|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 
+||     2, #02-25 t/friends t/owesMoney 
+|| ========================================================================
+|| Enter command: || [Command entered: add Valid Name 12345 e/valid@email.butNoPhonePrefix 
+||     a/valid, address] 
 || Invalid command format! 
-|| add: Adds a person to the address book. Contact details can be marked private by prepending 'p' to the prefix.
+|| add: Adds a person to the address book. Contact details can be marked 
+||     private by prepending 'p' to the prefix. 
 || Parameters: NAME [p]p/PHONE [p]e/EMAIL [p]a/ADDRESS  [t/TAG]...
-|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney
-|| ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/12345 valid@email.butNoPrefix a/valid, address]
+|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 
+||     2, #02-25 t/friends t/owesMoney 
+|| ========================================================================
+|| Enter command: || [Command entered: add Valid Name p/12345 valid@email.butNoPrefix 
+||     a/valid, address] 
 || Invalid command format! 
-|| add: Adds a person to the address book. Contact details can be marked private by prepending 'p' to the prefix.
+|| add: Adds a person to the address book. Contact details can be marked 
+||     private by prepending 'p' to the prefix. 
 || Parameters: NAME [p]p/PHONE [p]e/EMAIL [p]a/ADDRESS  [t/TAG]...
-|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney
-|| ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/12345 e/valid@email.butNoAddressPrefix valid, address]
+|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 
+||     2, #02-25 t/friends t/owesMoney 
+|| ========================================================================
+|| Enter command: || [Command entered: add Valid Name p/12345 
+||     e/valid@email.butNoAddressPrefix valid, address] 
 || Invalid command format! 
-|| add: Adds a person to the address book. Contact details can be marked private by prepending 'p' to the prefix.
+|| add: Adds a person to the address book. Contact details can be marked 
+||     private by prepending 'p' to the prefix. 
 || Parameters: NAME [p]p/PHONE [p]e/EMAIL [p]a/ADDRESS  [t/TAG]...
-|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney
-|| ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/12345 e/valid@email.butNoTagPrefix a/valid, address t/goodTag noPrefixTag]
+|| Example: add John Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 
+||     2, #02-25 t/friends t/owesMoney 
+|| ========================================================================
+|| Enter command: || [Command entered: add Valid Name p/12345 e/valid@email.butNoTagPrefix 
+||     a/valid, address t/goodTag noPrefixTag] 
 || Tags names should be alphanumeric
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  add []\[;] p/12345 e/valid@e.mail a/valid, address]
 || Person names should be spaces or alphabetic characters
-|| ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/not_numbers e/valid@e.mail a/valid, address]
+|| ========================================================================
+|| Enter command: || [Command entered: add Valid Name p/not_numbers e/valid@e.mail a/valid, 
+||     address] 
 || Person phone numbers should only contain numbers
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  add Valid Name p/12345 e/notAnEmail a/valid, address]
 || Person emails should be 2 alphanumeric/period strings separated by '@'
-|| ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/12345 e/valid@e.mail a/valid, address t/invalid_-[.tag]
+|| ========================================================================
+|| Enter command: || [Command entered: add Valid Name p/12345 e/valid@e.mail a/valid, address 
+||     t/invalid_-[.tag] 
 || Tags names should be alphanumeric
-|| ===================================================
-|| Enter command: || [Command entered:  add Adam Brown p/111111 e/adam@gmail.com a/111, alpha street]
-|| New person added: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
-|| ===================================================
+|| ========================================================================
+|| Enter command: || [Command entered: add Adam Brown p/111111 e/adam@gmail.com a/111, alpha 
+||     street] 
+|| New person added: Adam Brown Phone: 111111 Email: adam@gmail.com 
+||     Address: 111, alpha street Tags: 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
-|| 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 1 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Betsy Choo pp/222222 pe/benchoo@nus.edu.sg pa/222, beta street t/secretive]
-|| New person added: Betsy Choo Phone: (private) 222222 Email: (private) benchoo@nus.edu.sg Address: (private) 222, beta street Tags: [secretive]
-|| ===================================================
+|| ========================================================================
+|| Enter command: || [Command entered: add Betsy Choo pp/222222 pe/benchoo@nus.edu.sg pa/222, 
+||     beta street t/secretive] 
+|| New person added: Betsy Choo Phone: (private) 222222 Email: (private) 
+||     benchoo@nus.edu.sg Address: (private) 222, beta street Tags: 
+||     [secretive] 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
-|| 
 || 2 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Charlie Dickson pp/333333 e/charlie.d@nus.edu.sg a/333, gamma street t/friends t/school]
-|| New person added: Charlie Dickson Phone: (private) 333333 Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
-|| ===================================================
+|| ========================================================================
+|| Enter command: || [Command entered: add Charlie Dickson pp/333333 e/charlie.d@nus.edu.sg 
+||     a/333, gamma street t/friends t/school] 
+|| New person added: Charlie Dickson Phone: (private) 333333 Email: 
+||     charlie.d@nus.edu.sg Address: 333, gamma street Tags: 
+||     [school][friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
-|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
-|| 
+|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma 
+||     street Tags: [school][friends] 
 || 3 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Dickson Ee p/444444 pe/dickson@nus.edu.sg a/444, delta street t/friends]
-|| New person added: Dickson Ee Phone: 444444 Email: (private) dickson@nus.edu.sg Address: 444, delta street Tags: [friends]
-|| ===================================================
+|| ========================================================================
+|| Enter command: || [Command entered: add Dickson Ee p/444444 pe/dickson@nus.edu.sg a/444, 
+||     delta street t/friends] 
+|| New person added: Dickson Ee Phone: 444444 Email: (private) 
+||     dickson@nus.edu.sg Address: 444, delta street Tags: [friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
-|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma 
+||     street Tags: [school][friends] 
 || 	4. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 
 || 4 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy]
-|| New person added: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Address: (private) 555, epsilon street Tags: [tubers][starchy]
-|| ===================================================
+|| ========================================================================
+|| Enter command: || [Command entered: add Esther Potato p/555555 e/esther@not.a.real.potato 
+||     pa/555, epsilon street t/tubers t/starchy] 
+|| New person added: Esther Potato Phone: 555555 Email: 
+||     esther@not.a.real.potato Address: (private) 555, epsilon street 
+||     Tags: [tubers][starchy] 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
-|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma 
+||     street Tags: [school][friends] 
 || 	4. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 	5. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
-|| 
+|| 	5. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: 
+||     [tubers][starchy] 
 || 5 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy]
+|| ========================================================================
+|| Enter command: || [Command entered: add Esther Potato p/555555 e/esther@not.a.real.potato 
+||     pa/555, epsilon street t/tubers t/starchy] 
 || This person already exists in the address book
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view]
 || Invalid command format! 
-|| view: Views the non-private details of the person identified by the index number in the last shown person listing.
+|| view: Views the non-private details of the person identified by the 
+||     index number in the last shown person listing. 
 || Parameters: INDEX
 || Example: view 1
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall]
 || Invalid command format! 
-|| viewall: Views the non-private details of the person identified by the index number in the last shown person listing.
+|| viewall: Views the non-private details of the person identified by the 
+||     index number in the last shown person listing. 
 || Parameters: INDEX
 || Example: viewall 1
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view should be only one number]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall should only be one number]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view -1]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view 0]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view 6]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall -1]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 0]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 6]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view 1]
-|| Viewing person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
-|| ===================================================
+|| Viewing person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 
+||     111, alpha street Tags: 
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 1]
-|| Viewing person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
-|| ===================================================
+|| Viewing person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 
+||     111, alpha street Tags: 
+|| ========================================================================
 || Enter command: || [Command entered:  view 3]
-|| Viewing person: Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
-|| ===================================================
+|| Viewing person: Charlie Dickson Email: charlie.d@nus.edu.sg Address: 
+||     333, gamma street Tags: [school][friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  view 4]
-|| Viewing person: Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| ===================================================
+|| Viewing person: Dickson Ee Phone: 444444 Address: 444, delta street 
+||     Tags: [friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  view 5]
-|| Viewing person: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
-|| ===================================================
+|| Viewing person: Esther Potato Phone: 555555 Email: 
+||     esther@not.a.real.potato Tags: [tubers][starchy] 
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 3]
-|| Viewing person: Charlie Dickson Phone: (private) 333333 Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
-|| ===================================================
+|| Viewing person: Charlie Dickson Phone: (private) 333333 Email: 
+||     charlie.d@nus.edu.sg Address: 333, gamma street Tags: 
+||     [school][friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 4]
-|| Viewing person: Dickson Ee Phone: 444444 Email: (private) dickson@nus.edu.sg Address: 444, delta street Tags: [friends]
-|| ===================================================
+|| Viewing person: Dickson Ee Phone: 444444 Email: (private) 
+||     dickson@nus.edu.sg Address: 444, delta street Tags: [friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 5]
-|| Viewing person: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Address: (private) 555, epsilon street Tags: [tubers][starchy]
-|| ===================================================
+|| Viewing person: Esther Potato Phone: 555555 Email: 
+||     esther@not.a.real.potato Address: (private) 555, epsilon street 
+||     Tags: [tubers][starchy] 
+|| ========================================================================
 || Enter command: || [Command entered:  find]
 || Invalid command format! 
-|| find: Finds all persons whose names contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
+|| find: Finds all persons whose names contain any of the specified 
+||     keywords (case-sensitive) and displays them as a list with index 
+||     numbers. 
 || Parameters: KEYWORD [MORE_KEYWORDS]...
 || Example: find alice bob charlie
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  find bet]
 || 
 || 0 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  find 23912039120]
 || 
 || 0 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  find betsy]
 || 
 || 0 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  find Betsy]
 || 	1. Betsy Choo Tags: [secretive]
-|| 
 || 1 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  find Dickson]
-|| 	1. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	1. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma 
+||     street Tags: [school][friends] 
 || 	2. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 
 || 2 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  find Charlie Betsy]
 || 	1. Betsy Choo Tags: [secretive]
-|| 	2. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
-|| 
+|| 	2. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma 
+||     street Tags: [school][friends] 
 || 2 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete]
 || Invalid command format! 
-|| delete: Deletes the person identified by the index number used in the last person listing.
+|| delete: Deletes the person identified by the index number used in the 
+||     last person listing. 
 || Parameters: INDEX
 || Example: delete 1
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete should be only one number]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete -1]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete 0]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete 3]
 || The person index provided is invalid
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete 2]
-|| Deleted Person: Charlie Dickson Phone: (private) 333333 Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
-|| ===================================================
+|| Deleted Person: Charlie Dickson Phone: (private) 333333 Email: 
+||     charlie.d@nus.edu.sg Address: 333, gamma street Tags: 
+||     [school][friends] 
+|| ========================================================================
 || Enter command: || [Command entered:  delete 2]
 || Person could not be found in address book
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  view 2]
 || Person could not be found in address book
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  viewall 2]
 || Person could not be found in address book
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
 || 	3. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 	4. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
-|| 
+|| 	4. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: 
+||     [tubers][starchy] 
 || 4 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete 4]
-|| Deleted Person: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Address: (private) 555, epsilon street Tags: [tubers][starchy]
-|| ===================================================
+|| Deleted Person: Esther Potato Phone: 555555 Email: 
+||     esther@not.a.real.potato Address: (private) 555, epsilon street 
+||     Tags: [tubers][starchy] 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha 
+||     street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
 || 	3. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 
 || 3 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  delete 1]
-|| Deleted Person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
-|| ===================================================
+|| Deleted Person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 
+||     111, alpha street Tags: 
+|| ========================================================================
 || Enter command: || [Command entered:  list]
 || 	1. Betsy Choo Tags: [secretive]
 || 	2. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 
 || 2 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  list]
 || 
 || 0 persons listed!
-|| ===================================================
+|| ========================================================================
 || Enter command: || [Command entered:  exit]
 || Exiting Address Book as requested ...
-|| ===================================================
+|| ========================================================================
 || Good bye!
-|| ===================================================
-|| ===================================================
+|| ========================================================================
+|| ========================================================================

--- a/test/java/seedu/addressbook/commands/DeleteCommandTest.java
+++ b/test/java/seedu/addressbook/commands/DeleteCommandTest.java
@@ -18,7 +18,7 @@ import seedu.addressbook.data.person.Phone;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 import seedu.addressbook.data.tag.UniqueTagList;
-import seedu.addressbook.ui.TextUi;
+import seedu.addressbook.ui.Formatter;
 import seedu.addressbook.util.TestUtil;
 
 public class DeleteCommandTest {
@@ -148,7 +148,7 @@ public class DeleteCommandTest {
     private void assertDeletionSuccessful(int targetVisibleIndex, AddressBook addressBook,
                                           List<ReadOnlyPerson> displayList) throws PersonNotFoundException {
 
-        ReadOnlyPerson targetPerson = displayList.get(targetVisibleIndex - TextUi.DISPLAYED_INDEX_OFFSET);
+        ReadOnlyPerson targetPerson = displayList.get(targetVisibleIndex - Formatter.DISPLAYED_INDEX_OFFSET);
 
         AddressBook expectedAddressBook = TestUtil.clone(addressBook);
         expectedAddressBook.removePerson(targetPerson);


### PR DESCRIPTION
Extended W5.10 and added a very useful interface for managing screen width given a monospace-fonted CLI. No docs, helptexts needed to be updated for this. Running the program in real time will produce a very prettified output that always fits within a certain "screen width". Updated plain text output. 

Please take care when examining expected/ actual output. The actual application reads user enter commands as a newline but does not perform the same in the text-based test. For commands that exceed the screen width, you will see an extension. However, it works perfectly in the actual application. No JUnit assertion needs to be done for this feature. 

For ease of navigation, look at e6dd415cef08ca51f8ccf74450d550062570f6c8 onward if you have not reviewed my W5.10. All changes in W5.10 are necessary for this feature and cannot be implemented (in time) without.