### PR TITLE
[W5.2e][F11-A2]Denny Sunarjo

### DIFF
--- a/test/java/seedu/addressbook/common/UtilsTest.java
+++ b/test/java/seedu/addressbook/common/UtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Test;
@@ -35,6 +36,9 @@ public class UtilsTest {
         // confirms nulls inside the list are not considered
         List<Object> nullList = Arrays.asList((Object) null);
         assertFalse(Utils.isAnyNull(nullList));
+
+        // confirms nulls inside hashmap are not considered
+        assertFalse(Utils.isAnyNull(new HashMap<String, String>()));
     }
 
     @Test


### PR DESCRIPTION
confirms nulls inside hashmap are not considered for Utils.isAnyNull(Object...) method