### PR TITLE
[W5.4][W15-A2] Zames Chua Feike

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -49,6 +49,20 @@ Examples:
 * `add John Doe p/98765432 e/johnd@gmail.com a/John street, block 123, #01-01`
 * `add Betsy Crowe pp/1234567 e/betsycrowe@gmail.com pa/Newgate Prison t/criminal t/friend`
 
+### Adding a person: `edit`
+Edits the phone number, email, or address of an existing person in the Address Book<br>
+Format: `edit NAME p/PHONE_NUMBER` or `edit NAME e/EMAIL` or `edit NAME a/ADDRESS` 
+ 
+> Words in `UPPER_CASE` are the parameters 
+> 
+> This command only takes in NAME and one additional parameter:
+> PHONE_NUMBER, EMAIL, or ADDRESS
+
+Examples: 
+* `edit John Doe p/98765432`
+* `edit Betsy Crowe e/betsycrowe@gmail.com`
+* `edit James Chow a/Blk 551 Tampines St 53 #11-213`
+
 ### Listing all persons : `list`
 Shows a list of all persons in the address book.<br>
 Format: `list`

--- a/src/seedu/addressbook/commands/EditCommand.java
+++ b/src/seedu/addressbook/commands/EditCommand.java
@@ -11,7 +11,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the phone number, email, or address "
             + "of an existing person in the Address Book.\n"
-            + "Parameters: NAME p/PHONE \n"
+            + "Parameters: NAME p/PHONE\n"
             + "OR NAME e/EMAIL\n"
             + "OR NAME a/ADDRESS\n"
             + "Example: " + COMMAND_WORD

--- a/src/seedu/addressbook/commands/EditCommand.java
+++ b/src/seedu/addressbook/commands/EditCommand.java
@@ -1,0 +1,84 @@
+package seedu.addressbook.commands;
+
+import seedu.addressbook.data.exception.IllegalValueException;
+import seedu.addressbook.data.person.*;
+
+/**
+ * Edits details of an existing person in the Address Book
+ */
+public class EditCommand extends Command {
+    public static final String COMMAND_WORD = "edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits details of an existing person in the Address Book.\n"
+            + "Parameters: NAME p/PHONE(Optional) e/EMAIL(Optional) a/ADDRESS(Optional)\n"
+            + "Example: " + COMMAND_WORD
+            + " John Doe p/98765432";
+
+    public static final String MESSAGE_SUCCESS = "Person edited: %1$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "This person doesn't exist in the address book, "
+            + "use the 'add' command to add a new person!";
+    public static final String MESSAGE_INCORRECT_PARAMETERS = "The parameters supplied seem to be incorrect!";
+    public static final String MESSAGE_FIELD_TYPE_NOT_RECOGNISED = "The field type is not recognised, "
+            + "Check if you entered it correctly!";
+
+    private final String nameToSearch;
+    private final String fieldType;
+    private final String newValue;
+    private Person personToEdit;
+
+    public EditCommand(String nameToSearch, String fieldType, String newValue)
+            throws IllegalValueException {
+        this.nameToSearch = nameToSearch;
+        this.fieldType = fieldType;
+        this.newValue = newValue;
+    }
+
+    public ReadOnlyPerson getPerson() {
+        return personToEdit;
+    }
+
+    @Override
+    public CommandResult execute() {
+        try {
+            personToEdit = getPerson(nameToSearch);
+            switch (fieldType) {
+                case "p":
+                    personToEdit.setPhone(newValue);
+                    break;
+                case "a":
+                    personToEdit.setAddress(newValue);
+                    break;
+                case "e":
+                    personToEdit.setEmail(newValue);
+                    break;
+                default:
+                    return new CommandResult(MESSAGE_FIELD_TYPE_NOT_RECOGNISED);
+            }
+            return new CommandResult(String.format(MESSAGE_SUCCESS, personToEdit));
+        } catch (UniquePersonList.PersonNotFoundException dpe) {
+            return new CommandResult(MESSAGE_PERSON_NOT_FOUND);
+        } catch (IllegalValueException ive) {
+            return new CommandResult(MESSAGE_INCORRECT_PARAMETERS);
+        }
+    }
+
+    /**
+     * Retrieves all persons in the address book whose names contain some of the specified keywords.
+     *
+     * @param name for searching
+     * @return persons found
+     */
+    private Person getPerson(String name) throws UniquePersonList.PersonNotFoundException, IllegalValueException {
+        Name searchName = new Name(name);
+
+        for (Person person : addressBook.getAllPersons()) {
+            final Name personName = person.getName();
+            if (searchName.equals(personName)) {
+                return person;
+            }
+        }
+        // If the person does not exist in the Address Book yet
+        throw new UniquePersonList.PersonNotFoundException();
+    }
+}
+

--- a/src/seedu/addressbook/commands/EditCommand.java
+++ b/src/seedu/addressbook/commands/EditCommand.java
@@ -9,8 +9,11 @@ import seedu.addressbook.data.person.*;
 public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits details of an existing person in the Address Book.\n"
-            + "Parameters: NAME p/PHONE(Optional) e/EMAIL(Optional) a/ADDRESS(Optional)\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the phone number, email, or address "
+            + "of an existing person in the Address Book.\n"
+            + "Parameters: NAME p/PHONE \n"
+            + "OR NAME e/EMAIL\n"
+            + "OR NAME a/ADDRESS\n"
             + "Example: " + COMMAND_WORD
             + " John Doe p/98765432";
 

--- a/src/seedu/addressbook/data/person/Person.java
+++ b/src/seedu/addressbook/data/person/Person.java
@@ -1,5 +1,6 @@
 package seedu.addressbook.data.person;
 
+import seedu.addressbook.data.exception.IllegalValueException;
 import seedu.addressbook.data.tag.UniqueTagList;
 
 import java.util.Objects;
@@ -57,6 +58,18 @@ public class Person implements ReadOnlyPerson {
     @Override
     public UniqueTagList getTags() {
         return new UniqueTagList(tags);
+    }
+
+    public void setPhone(String newPhone) throws IllegalValueException {
+        this.phone = new Phone(newPhone, phone.isPrivate());
+    }
+
+    public void setEmail(String newEmail) throws IllegalValueException {
+        this.email = new Email(newEmail, email.isPrivate());
+    }
+
+    public void setAddress(String newAddress) throws IllegalValueException  {
+        this.address = new Address(newAddress, address.isPrivate());
     }
 
     /**

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -22,6 +22,7 @@ import seedu.addressbook.commands.IncorrectCommand;
 import seedu.addressbook.commands.ListCommand;
 import seedu.addressbook.commands.ViewAllCommand;
 import seedu.addressbook.commands.ViewCommand;
+import seedu.addressbook.commands.EditCommand;
 import seedu.addressbook.data.exception.IllegalValueException;
 
 /**
@@ -40,6 +41,10 @@ public class Parser {
                     + " (?<isEmailPrivate>p?)e/(?<email>[^/]+)"
                     + " (?<isAddressPrivate>p?)a/(?<address>[^/]+)"
                     + "(?<tagArguments>(?: t/[^/]+)*)"); // variable number of tags
+
+    public static final Pattern PERSON_EDIT_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
+            Pattern.compile("(?<name>[^/]+)"
+                    + " (?<fieldType>p?a?e?)/(?<newValue>[^/]+)"); // variable number of tags
 
 
     /**
@@ -99,6 +104,9 @@ public class Parser {
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 
+        case EditCommand.COMMAND_WORD:
+            return prepareEdit(arguments);
+
         case HelpCommand.COMMAND_WORD: // Fallthrough
         default:
             return new HelpCommand();
@@ -131,6 +139,31 @@ public class Parser {
                     isPrivatePrefixPresent(matcher.group("isAddressPrivate")),
 
                     getTagsFromArgs(matcher.group("tagArguments"))
+            );
+        } catch (IllegalValueException ive) {
+            return new IncorrectCommand(ive.getMessage());
+        }
+    }
+
+    /**
+     * Parses arguments in the context of the edit person command.
+     *
+     * @param args full command args string
+     * @return the prepared command
+     */
+    private Command prepareEdit(String args) {
+        final Matcher matcher = PERSON_EDIT_DATA_ARGS_FORMAT.matcher(args.trim());
+        // Validate arg string format
+        if (!matcher.matches()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
+        try {
+            return new EditCommand(
+                    matcher.group("name"),
+
+                    matcher.group("fieldType"),
+
+                    matcher.group("newValue")
             );
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -290,6 +290,29 @@
 || 
 || 2 persons listed!
 || ===================================================
+|| Enter command: || [Command entered:  edit Betsy Choo k/INVALID]
+|| Invalid command format! 
+|| edit: Edits the phone number, email, or address of an existing person in the Address Book.
+|| Parameters: NAME p/PHONE
+|| OR NAME e/EMAIL
+|| OR NAME a/ADDRESS
+|| Example: edit John Doe p/98765432
+|| ===================================================
+|| Enter command: || [Command entered:  edit Betsy Choo e/not an email]
+|| The parameters supplied seem to be incorrect!
+|| ===================================================
+|| Enter command: || [Command entered:  edit Elon Musk p/62353535]
+|| This person doesn't exist in the address book, use the 'add' command to add a new person!
+|| ===================================================
+|| Enter command: || [Command entered:  edit Betsy Choo p/62353535]
+|| Person edited: Betsy Choo Phone: (private) 62353535 Email: (private) benchoo@nus.edu.sg Address: (private) 222, beta street Tags: [secretive]
+|| ===================================================
+|| Enter command: || [Command entered:  edit Betsy Choo e/newEmail@domain.com]
+|| Person edited: Betsy Choo Phone: (private) 62353535 Email: (private) newEmail@domain.com Address: (private) 222, beta street Tags: [secretive]
+|| ===================================================
+|| Enter command: || [Command entered:  edit Betsy Choo a/My New Address Street #12-213]
+|| Person edited: Betsy Choo Phone: (private) 62353535 Email: (private) newEmail@domain.com Address: (private) My New Address Street #12-213 Tags: [secretive]
+|| ===================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!
 || ===================================================

--- a/test/input.txt
+++ b/test/input.txt
@@ -141,6 +141,24 @@
   list
 
 ##########################################################
+# test edit person command
+##########################################################
+
+  # should consider invalid field types
+  edit Betsy Choo k/INVALID
+  # should consider invalid arguments
+  edit Betsy Choo e/not an email
+  # should not update if person does not exist in AddressBook
+  edit Elon Musk p/62353535
+
+  # update phone
+  edit Betsy Choo p/62353535
+  # update email
+  edit Betsy Choo e/newEmail@domain.com
+  # update address
+  edit Betsy Choo a/My New Address Street #12-213
+
+##########################################################
 # test clear command
 ##########################################################
 

--- a/test/java/seedu/addressbook/commands/EditCommandTest.java
+++ b/test/java/seedu/addressbook/commands/EditCommandTest.java
@@ -1,27 +1,15 @@
 package seedu.addressbook.commands;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.Test;
 
 import seedu.addressbook.data.AddressBook;
-import seedu.addressbook.data.exception.IllegalValueException;
-import seedu.addressbook.data.person.Address;
-import seedu.addressbook.data.person.Email;
-import seedu.addressbook.data.person.Name;
 import seedu.addressbook.data.person.Person;
-import seedu.addressbook.data.person.Phone;
 import seedu.addressbook.data.person.ReadOnlyPerson;
-import seedu.addressbook.data.person.UniquePersonList;
 import seedu.addressbook.util.TestUtil;
 
 public class EditCommandTest {

--- a/test/java/seedu/addressbook/commands/EditCommandTest.java
+++ b/test/java/seedu/addressbook/commands/EditCommandTest.java
@@ -1,0 +1,156 @@
+package seedu.addressbook.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import seedu.addressbook.data.AddressBook;
+import seedu.addressbook.data.exception.IllegalValueException;
+import seedu.addressbook.data.person.Address;
+import seedu.addressbook.data.person.Email;
+import seedu.addressbook.data.person.Name;
+import seedu.addressbook.data.person.Person;
+import seedu.addressbook.data.person.Phone;
+import seedu.addressbook.data.person.ReadOnlyPerson;
+import seedu.addressbook.data.person.UniquePersonList;
+import seedu.addressbook.util.TestUtil;
+
+public class EditCommandTest {
+    private static final List<ReadOnlyPerson> EMPTY_PERSON_LIST = Collections.emptyList();
+    
+    private static final String FIELD_TYPE_PHONE = "p";
+    private static final String FIELD_TYPE_EMAIL = "e";
+    private static final String FIELD_TYPE_ADDRESS = "a";
+    private static final String FIELD_TYPE_INVALID = "i";
+
+    private static final String VALID_VALUE_PHONE = "99999999";
+    private static final String VALID_VALUE_EMAIL = "newEmail@domain.com";
+    private static final String VALID_VALUE_ADDRESS = "New Address";
+
+    private static final String INVALID_VALUE_PHONE = "invalid";
+    private static final String INVALID_VALUE_EMAIL = "invalid";
+    
+    @Test
+    public void editCommand_invalidPhone_throwsException() throws Exception {
+        // Add test person
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(p);
+        
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_PHONE, INVALID_VALUE_PHONE);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+        
+        assertEquals(EditCommand.MESSAGE_INCORRECT_PARAMETERS, result.feedbackToUser);
+    }
+    
+    @Test
+    public void editCommand_validPhone_correctResult() throws Exception{
+        // Add test person
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(p);
+        
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_PHONE, VALID_VALUE_PHONE);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+
+        assertEquals(String.format(EditCommand.MESSAGE_SUCCESS, p), result.feedbackToUser);
+    }
+    
+    @Test
+    public void editCommand_invalidEmail_throwsException() throws Exception {
+        // Add test person
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(p);
+
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_EMAIL, INVALID_VALUE_EMAIL);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+
+        assertEquals(EditCommand.MESSAGE_INCORRECT_PARAMETERS, result.feedbackToUser);
+    }
+    
+    @Test
+    public void editCommand_validEmail_correctResult() throws Exception{
+        // Add test person
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(p);
+
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_EMAIL, VALID_VALUE_EMAIL);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+
+        assertEquals(String.format(EditCommand.MESSAGE_SUCCESS, p), result.feedbackToUser);
+    }
+    
+    @Test
+    public void editCommand_validAddress_correctResult() throws Exception{
+        // Add test person
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(p);
+        
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_ADDRESS, VALID_VALUE_ADDRESS);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+
+        assertEquals(String.format(EditCommand.MESSAGE_SUCCESS, p), result.feedbackToUser);
+    }
+
+    @Test
+    public void editCommand_invalidField_throwsExcetion() throws Exception{
+        // Add test person
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(p);
+
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_INVALID, VALID_VALUE_PHONE);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+
+        assertEquals(EditCommand.MESSAGE_FIELD_TYPE_NOT_RECOGNISED, result.feedbackToUser);
+    }
+
+    @Test
+    public void editCommand_personDoesNotExist_throwsExcetion() throws Exception{
+        // Create test person without adding to Address Book
+        Person p = TestUtil.generateTestPerson();
+        AddressBook addressBook = new AddressBook();
+
+        // Edit test person
+        String personName = p.getName().toString();
+        EditCommand editCommand = new EditCommand(personName, FIELD_TYPE_PHONE, VALID_VALUE_PHONE);
+        editCommand.setData(addressBook, EMPTY_PERSON_LIST);
+        CommandResult result = editCommand.execute();
+
+        assertEquals(EditCommand.MESSAGE_PERSON_NOT_FOUND, result.feedbackToUser);
+    }
+    
+}
+
+
+


### PR DESCRIPTION
### Brief description
This PR fulfills LO-2KLoC

I added an edit command, allows you to edit the phone, address, and email fields of a person.
This pull request includes additions to JUnit tests and I/O tests to support the new command.

### Motivation
Previously, there was no way for one to edit the details of a contact in the Address Book once you've added it in, except delete then re-enter the person again.

Now, you can simply call something like `edit Zames Chua p/99999999` to change his phone number.

### Example valid commands
`edit Zames Chua p/99999999` 
`edit Zames Chua e/email@domain.com` 
`edit Zames Chua a/My New Address` 

### Reviewers
@JasmineSee @ShaocongDong @kosyoz 