### PR TITLE
[W5.4][F10-A2] Joanne Ong

### DIFF
--- a/src/seedu/addressbook/commands/FindCommand.java
+++ b/src/seedu/addressbook/commands/FindCommand.java
@@ -16,8 +16,8 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names/ *public* emails" +
+            " contain any of " + "the specified keywords (case-sensitive) and displays them as a list with index gnumbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
@@ -36,7 +36,7 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        final List<ReadOnlyPerson> personsFound = getPersonsWithNameContainingAnyKeyword(keywords);
+        final List<ReadOnlyPerson> personsFound = getPersonsWithNameOrPublicEmailContainingAnyKeyword(keywords);
         return new CommandResult(getMessageForPersonListShownSummary(personsFound), personsFound);
     }
 
@@ -46,11 +46,17 @@ public class FindCommand extends Command {
      * @param keywords for searching
      * @return list of persons found
      */
-    private List<ReadOnlyPerson> getPersonsWithNameContainingAnyKeyword(Set<String> keywords) {
+    private List<ReadOnlyPerson> getPersonsWithNameOrPublicEmailContainingAnyKeyword(Set<String> keywords) {
         final List<ReadOnlyPerson> matchedPersons = new ArrayList<>();
         for (ReadOnlyPerson person : addressBook.getAllPersons()) {
             final Set<String> wordsInName = new HashSet<>(person.getName().getWordsInName());
             if (!Collections.disjoint(wordsInName, keywords)) {
+                matchedPersons.add(person);
+            }
+
+            final Set<String> wordsInEmail = new HashSet<>(person.getEmail().getWordsInEmail());
+            if (!Collections.disjoint(wordsInEmail, keywords)
+                    && !person.getEmail().isPrivate()) {
                 matchedPersons.add(person);
             }
         }

--- a/src/seedu/addressbook/commands/FindCommand.java
+++ b/src/seedu/addressbook/commands/FindCommand.java
@@ -16,10 +16,10 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names/ *public* emails" +
-            " contain any of " + "the specified keywords (case-sensitive) and displays them as a list with index gnumbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names or public emails" +
+            " contain any of " + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " alice bob charlie public@email.com";
 
     private final Set<String> keywords;
 

--- a/src/seedu/addressbook/data/person/Email.java
+++ b/src/seedu/addressbook/data/person/Email.java
@@ -2,6 +2,9 @@ package seedu.addressbook.data.person;
 
 import seedu.addressbook.data.exception.IllegalValueException;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
@@ -35,6 +38,13 @@ public class Email {
      */
     public static boolean isValidEmail(String test) {
         return test.matches(EMAIL_VALIDATION_REGEX);
+    }
+
+    /**
+     * Retrieves a listing of every word in the email, in order.
+     */
+    public List<String> getWordsInEmail() {
+        return Arrays.asList(value.split("\\s+"));
     }
 
     @Override

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -14,9 +14,9 @@
 || Example: delete 1
 || Clears address book permanently.
 || Example: clear
-|| find: Finds all persons whose names contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
+|| find: Finds all persons whose names or public emails contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
 || Parameters: KEYWORD [MORE_KEYWORDS]...
-|| Example: find alice bob charlie
+|| Example: find alice bob charlie public@email.com
 || list: Displays all persons in the address book as a list with index numbers.
 || Example: list
 || view: Views the non-private details of the person identified by the index number in the last shown person listing.
@@ -135,6 +135,19 @@
 || 
 || 5 persons listed!
 || ===================================================
+|| Enter command: || [Command entered:  add Fish Leong p/666666 e/adam@gmail.com a/666, zeta street]
+|| New person added: Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
+|| ===================================================
+|| Enter command: || [Command entered:  list]
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	2. Betsy Choo Tags: [secretive]
+|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	4. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
+|| 	5. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
+|| 	6. Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
+|| 
+|| 6 persons listed!
+|| ===================================================
 || Enter command: || [Command entered:  add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy]
 || This person already exists in the address book
 || ===================================================
@@ -163,7 +176,7 @@
 || The person index provided is invalid
 || ===================================================
 || Enter command: || [Command entered:  view 6]
-|| The person index provided is invalid
+|| Viewing person: Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
 || ===================================================
 || Enter command: || [Command entered:  viewall -1]
 || The person index provided is invalid
@@ -171,7 +184,7 @@
 || Enter command: || [Command entered:  viewall 0]
 || The person index provided is invalid
 || ===================================================
-|| Enter command: || [Command entered:  viewall 6]
+|| Enter command: || [Command entered:  viewall 7]
 || The person index provided is invalid
 || ===================================================
 || Enter command: || [Command entered:  view 1]
@@ -200,11 +213,15 @@
 || ===================================================
 || Enter command: || [Command entered:  find]
 || Invalid command format! 
-|| find: Finds all persons whose names contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
+|| find: Finds all persons whose names or public emails contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
 || Parameters: KEYWORD [MORE_KEYWORDS]...
-|| Example: find alice bob charlie
+|| Example: find alice bob charlie public@email.com
 || ===================================================
 || Enter command: || [Command entered:  find bet]
+|| 
+|| 0 persons listed!
+|| ===================================================
+|| Enter command: || [Command entered:  find charlie.d@nus]
 || 
 || 0 persons listed!
 || ===================================================
@@ -212,12 +229,29 @@
 || 
 || 0 persons listed!
 || ===================================================
+|| Enter command: || [Command entered:  find 123@email.com]
+|| 
+|| 0 persons listed!
+|| ===================================================
 || Enter command: || [Command entered:  find betsy]
+|| 
+|| 0 persons listed!
+|| ===================================================
+|| Enter command: || [Command entered:  find CHarLie.d@nus.edu.sg]
+|| 
+|| 0 persons listed!
+|| ===================================================
+|| Enter command: || [Command entered:  find benchoo@nus.edu.sg]
 || 
 || 0 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  find Betsy]
 || 	1. Betsy Choo Tags: [secretive]
+|| 
+|| 1 persons listed!
+|| ===================================================
+|| Enter command: || [Command entered:  find charlie.d@nus.edu.sg]
+|| 	1. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
 || 
 || 1 persons listed!
 || ===================================================
@@ -227,9 +261,21 @@
 || 
 || 2 persons listed!
 || ===================================================
+|| Enter command: || [Command entered:  find adam@gmail.com]
+|| 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
+|| 	2. Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
+|| 
+|| 2 persons listed!
+|| ===================================================
 || Enter command: || [Command entered:  find Charlie Betsy]
 || 	1. Betsy Choo Tags: [secretive]
 || 	2. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 
+|| 2 persons listed!
+|| ===================================================
+|| Enter command: || [Command entered:  find charlie.d@nus.edu.sg esther@not.a.real.potato]
+|| 	1. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	2. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
 || 
 || 2 persons listed!
 || ===================================================
@@ -252,7 +298,7 @@
 || The person index provided is invalid
 || ===================================================
 || Enter command: || [Command entered:  delete 2]
-|| Deleted Person: Charlie Dickson Phone: (private) 333333 Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| Deleted Person: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Address: (private) 555, epsilon street Tags: [tubers][starchy]
 || ===================================================
 || Enter command: || [Command entered:  delete 2]
 || Person could not be found in address book
@@ -266,29 +312,32 @@
 || Enter command: || [Command entered:  list]
 || 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
-|| 	3. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
-|| 	4. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
+|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	4. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
+|| 	5. Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
 || 
-|| 4 persons listed!
+|| 5 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  delete 4]
-|| Deleted Person: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Address: (private) 555, epsilon street Tags: [tubers][starchy]
+|| Deleted Person: Dickson Ee Phone: 444444 Email: (private) dickson@nus.edu.sg Address: 444, delta street Tags: [friends]
 || ===================================================
 || Enter command: || [Command entered:  list]
 || 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
-|| 	3. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
+|| 	3. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	4. Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
 || 
-|| 3 persons listed!
+|| 4 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  delete 1]
 || Deleted Person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
 || ===================================================
 || Enter command: || [Command entered:  list]
 || 	1. Betsy Choo Tags: [secretive]
-|| 	2. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
+|| 	2. Charlie Dickson Email: charlie.d@nus.edu.sg Address: 333, gamma street Tags: [school][friends]
+|| 	3. Fish Leong Phone: 666666 Email: adam@gmail.com Address: 666, zeta street Tags: 
 || 
-|| 2 persons listed!
+|| 3 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!

--- a/test/input.txt
+++ b/test/input.txt
@@ -23,7 +23,7 @@
   list
 
 ##########################################################
-# test add person command, setup state for futuer tests
+# test add person command, setup state for future tests
 ##########################################################
 
   # should catch invalid args format
@@ -50,6 +50,8 @@
   list
   add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy
   list
+  add Fish Leong p/666666 e/adam@gmail.com a/666, zeta street
+  list
 
   # should not allow adding duplicate persons
   add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy
@@ -70,7 +72,7 @@
   view 6
   viewall -1
   viewall 0
-  viewall 6
+  viewall 7
 
   # should show all non private for both view and viewall
   view 1
@@ -92,25 +94,33 @@
 
   # should consider no keywords as invalid command format
   find
-  # should only match full words in person names
+  # should only match full words in person names/ public email
   find bet
+  find charlie.d@nus
   # does not match if none have keyword
   find 23912039120
+  find 123@email.com
   # matching should be case-sensitive
   find betsy
+  find CHarLie.d@nus.edu.sg
+  # does not match if email is private
+  find benchoo@nus.edu.sg
 
-  # find unique keyword
+  # find unique keyword/ public email
   find Betsy
+  find charlie.d@nus.edu.sg
   # find multiple with same keyword
   find Dickson
+  find adam@gmail.com
   # find multiple with some keywords
   find Charlie Betsy
+  find charlie.d@nus.edu.sg esther@not.a.real.potato
 
 ##########################################################
 # test delete person command
 ##########################################################
 
-# last active view: [1] betsy [2] charlie
+# last active view: [1] charlie [2] esther
 
   # should catch invalid args format
   delete

--- a/test/java/seedu/addressbook/commands/FindCommandTest.java
+++ b/test/java/seedu/addressbook/commands/FindCommandTest.java
@@ -22,21 +22,34 @@ public class FindCommandTest {
 
     @Test
     public void execute() throws IllegalValueException {
-        //same word, same case: matched
+        //same word, same case, public email: matched
         assertFindCommandBehavior(new String[]{"Amy"}, Arrays.asList(td.amy));
+        assertFindCommandBehavior(new String[]{"ab@gmail.com"}, Arrays.asList(td.amy));
 
-        //same word, different case: not matched
+        //same word, different case, public email: not matched
         assertFindCommandBehavior(new String[]{"aMy"}, Collections.emptyList());
+        assertFindCommandBehavior(new String[]{"Ab@gMail.com"}, Collections.emptyList());
 
-        //partial word: not matched
+        //partial word, public email: not matched
         assertFindCommandBehavior(new String[]{"my"}, Collections.emptyList());
+        assertFindCommandBehavior(new String[]{"ab@gmail"}, Collections.emptyList());
 
-        //multiple words: matched
+        //multiple words, public emails: matched
         assertFindCommandBehavior(new String[]{"Amy", "Bill", "Candy", "Destiny"},
                 Arrays.asList(td.amy, td.bill, td.candy));
+        assertFindCommandBehavior(new String[]{"ab@gmail.com", "bc@gmail.com", "cd@gmail.com"},
+                Arrays.asList(td.amy, td.bill, td.candy));
 
-        //repeated keywords: matched
+        //repeated keywords, public email: matched
         assertFindCommandBehavior(new String[]{"Amy", "Amy"}, Arrays.asList(td.amy));
+        assertFindCommandBehavior(new String[]{"ab@gmail.com", "ab@gmail.com"}, Arrays.asList(td.amy));
+
+        //private email: not matched
+        assertFindCommandBehavior(new String[]{"ss@tt.com"}, Collections.emptyList());
+        assertFindCommandBehavior(new String[]{"sS@tt.com"}, Collections.emptyList());
+        assertFindCommandBehavior(new String[]{"ss@tt"}, Collections.emptyList());
+        assertFindCommandBehavior(new String[]{"ss@tt.com", "ab@gmail.com"}, Arrays.asList(td.amy));
+        assertFindCommandBehavior(new String[]{"ss@tt.com", "ss@tt.com"}, Collections.emptyList());
 
         //Keyword matching a word in address: not matched
         assertFindCommandBehavior(new String[]{"Clementi"}, Collections.emptyList());


### PR DESCRIPTION
Enhance the find command so that users can find matching public email addresses in addition to names. The finding is case sensitive and must match the full email address in order to find the person. Additionally, if the email address is private, then it will not be found even if the exact email address is searched for.